### PR TITLE
remove kicad lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# For PCBs designed using KiCad: https://www.kicad.org/
+# Format documentation: https://kicad.org/help/file-formats/
+
+# Temporary files
+*.000
+*.bak
+*.bck
+*.kicad_pcb-bak
+*.kicad_sch-bak
+*-backups
+*.kicad_prl
+*.sch-bak
+*~
+_autosave-*
+*.tmp
+*-save.pro
+*-save.kicad_pcb
+fp-info-cache
+~*.lck
+\#auto_saved_files#
+
+# Netlist files (exported from Eeschema)
+*.net
+
+# Autorouter files (exported from Pcbnew)
+*.dsn
+*.ses
+
+# Exported BOM files
+*.xml
+*.csv
+
+# Archived Backups (KiCad 6.0)
+**/*-backups/*.zip
+
+\#auto_saved_files\#

--- a/~esp32_mine.kicad_pcb.lck
+++ b/~esp32_mine.kicad_pcb.lck
@@ -1,1 +1,0 @@
-{"hostname":"LAPTOP-KUJHF67G","username":"monte"}

--- a/~esp32_mine.kicad_sch.lck
+++ b/~esp32_mine.kicad_sch.lck
@@ -1,1 +1,0 @@
-{"hostname":"LAPTOP-KUJHF67G","username":"monte"}


### PR DESCRIPTION
when i opened this project just after cloning, kicad told me to be careful because monte had the file open on LAPTOP-KUJHF67G.

this commit removes the 2 lockfiles and creates a gitignore to ignore those and similar files automatically.